### PR TITLE
Switch to storing strings and defaultlanguage as @properties

### DIFF
--- a/Classes/MCLocalization.m
+++ b/Classes/MCLocalization.m
@@ -10,10 +10,15 @@
 
 #define MCLOCALIZATION_PREFERRED_LOCALE_KEY @"MCLOCALIZATION_PREFERRED_LOCALE_KEY"
 
+@interface MCLocalization ()
+
+@property (nonatomic, retain) NSDictionary *strings;
+@property (nonatomic, retain) NSString *defaultLanguage;
+
+@end
+
 @implementation MCLocalization {
     NSString * _language;
-    NSDictionary * _strings;
-    NSString * _defaultLanguage;
 }
 
 // Singleton
@@ -33,12 +38,12 @@
 
 - (void)loadFromJSONFile:(NSString *)fileName defaultLanguage:(NSString *)defaultLanguage
 {
-    _strings = nil;
-    
+    self.strings = nil;
+
     NSData * JSONData = [NSData dataWithContentsOfFile:fileName];
-    _strings = [NSJSONSerialization JSONObjectWithData:JSONData options:0 error:nil];
-    
-    _defaultLanguage = defaultLanguage;
+    self.strings = [NSJSONSerialization JSONObjectWithData:JSONData options:0 error:nil];
+
+    self.defaultLanguage = defaultLanguage;
 }
 
 + (void)loadFromJSONFile:(NSString *)fileName defaultLanguage:(NSString *)defaultLanguage
@@ -51,7 +56,7 @@
 
 - (NSArray *)supportedLanguages
 {
-    return [_strings allKeys];
+    return [self.strings allKeys];
 }
 
 #pragma mark -
@@ -72,7 +77,7 @@
     
     // In the worst case, return default setting
     if (language == nil) {
-        language = _defaultLanguage;
+        language = self.defaultLanguage;
     }
     
     return language;
@@ -113,7 +118,7 @@
 
 - (NSString *)stringForKey:(NSString *)key language:(NSString *)language
 {
-    NSDictionary * langugeStrings = _strings[language];
+    NSDictionary * langugeStrings = self.strings[language];
     NSString * string = langugeStrings[key];
 #if DEBUG
     if (!string) {


### PR DESCRIPTION
Switched to using @properties to avoid issues when running when using CocoaPods. Without this change, when the code is run the `_strings` ivar seems to get nulled out, leading to a bad access error as the app is used. I'm not sure exactly what causes this, but perhaps including it as a Pod (and thus as a separate build target) means that ARC doesn't know if it should hold onto the reference and erroneously removes it. Switching to @properties means that the MCLocalization singleton should hold onto the `strings` reference while it is in memory. 
